### PR TITLE
2026 Municipality updates

### DIFF
--- a/kommuner.json
+++ b/kommuner.json
@@ -1367,6 +1367,22 @@
     "Palmesondag": "08-18"
   },
   {
+    "kommuneNavn": "Haram",
+    "utvidet": true,
+    "Electionday": "08-20",
+    "Forstejuledag": "08-18",
+    "Forstenyttarsdag": "08-18",
+    "Forstepinsedag": "08-18",
+    "Grunnlovsdag": "standard",
+    "Kristihimmelfartsdag": "08-20",
+    "Offentlighoytidsdag": "standard",
+    "Skjertorsdag": "08-18",
+    "Forstepaskedag": "08-18",
+    "default": "08-20",
+    "sat": "08-18",
+    "Palmesondag": "08-18"
+  },
+  {
     "kommuneNavn": "Hareid",
     "utvidet": true,
     "Electionday": "none",

--- a/kommuner.json
+++ b/kommuner.json
@@ -2121,6 +2121,7 @@
   },
   {
     "kommuneNavn": "Levanger",
+    "altNavn": "Levangke",
     "utvidet": true,
     "Electionday": "none",
     "Forstejuledag": "08-16",
@@ -3042,6 +3043,7 @@
   },
   {
     "kommuneNavn": "Rana",
+    "altNavn": "Raane",
     "utvidet": true,
     "Electionday": "none",
     "Forstejuledag": "08-18",
@@ -3741,6 +3743,7 @@
   },
   {
     "kommuneNavn": "Steinkjer",
+    "altNavn": "Stïentjen tjïelte",
     "utvidet": true,
     "Electionday": "none",
     "Forstejuledag": "08-16",
@@ -3965,6 +3968,7 @@
   },
   {
     "kommuneNavn": "Sørfold",
+    "altNavn": "Fuolldá",
     "utvidet": true,
     "Electionday": "none",
     "Forstejuledag": "08-18",


### PR DESCRIPTION
After 2024, Ålesund kommune seemed to have split up into Ålesund, and Haram Kommune. Gathered the sales times from
[their own website](https://haram.kommune.no/naringsliv-landbruk-og-miljo/naring/sal-servering-og-skjenking/salstider-ol/)

So added in Haram kommune

Also added in some addiitonal sami names based off of recent changes listed in [SSB](https://www.ssb.no/metadata/alle-endringer-i-de-regionale-inndelingene)